### PR TITLE
Updated WiFi configuration to remove security vulnerability on wirele…

### DIFF
--- a/Configure.h
+++ b/Configure.h
@@ -1,27 +1,27 @@
 // un-comment out this line if you want to see debug messages over the serial connection
-//#define DEBUG 1
+#define DEBUG 1
 
 // The serial speed used for debugging messages
 #define SERIALRATE 115200
 
 // This pin will be held high when the program is running ... you can connect an LED through a 330 Ohm resistor to show the power is on
-#define POWERPIN 13
+#define POWERPIN 15
 
 // This pin will be held high when any button is pressed ... you can connect an LED to provide button press feedback to the user
 #define PRESSPIN 2
 
 // This is the IP address of the machine running xSchedule
-#define SERVER_IP "192.168.100.10"
+#define SERVER_IP "192.168.1.58"
 
 // This is the xSchedule port
-#define WEBPORT 81
+#define WEBPORT 80
 
 // This is the number of buttons connected
-#define BUTTONS 2
+#define BUTTONS 3
 
 // Define the pins to use ... each pin maps to a button named ArduinoButton_n where n is the one based index in the table below
-// This must be at least as large as the number of buttons above. Excess pins are ignored
-short pins[] = {14, 12, 16, 5, 4, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41};
+// This must be at least as large as the number of buttons above. Excess pins are ignored.
+// This list of pins is ordered from best to worst choice. Not all GPIO pins can be used. 
+short pins[] = {14, 12, 13, 5, 4, 3, 16};
 
 // NOTE: When wiring up the buttons the buttons should short the pin to ground when pressed. When not pressed the pin should be free floating
-

--- a/ESP8266_xScheduleButtonsDemo.ino
+++ b/ESP8266_xScheduleButtonsDemo.ino
@@ -1,9 +1,10 @@
-#include <ESP8266WiFi.h>
-#include <configure.h>
 
-const char* ssid     = "WiFi SSID";
-const char* password = "WiFi Pawword"; 
-const char* host = SERVER_IP;
+#include <ESP8266WiFi.h>
+#include "configure.h"
+
+const char* ssid     = "xxxx"; // your WiFi SSID
+const char* password = "xxxx"; // your WiFi Password
+const char* host = SERVER_IP; // the IP address of the server running xSchedule
 short pressed[100]; // an array keeping state of the buttons between loops
 short buttons; // number of buttons
 int Processed = 0; //for debugging
@@ -39,7 +40,6 @@ void setup(){
     pressed[i] = LOW;
   }
 
-
   // We start by connecting to a WiFi network
 #ifdef DEBUG
   Serial.println();
@@ -48,7 +48,10 @@ void setup(){
   Serial.println(ssid);
 #endif
 
-  WiFi.config(IPAddress(192, 168, 100, 74), IPAddress(192, 168, 100, 10), IPAddress(192, 168, 100, 10));
+  // Next, we configure the network connection, making sure the WiFi is in Station mode and not AP+Station
+  // The IP address is configured manually: 3-5 octet groups of localIP, gateway, subnet, and then optional DNS server addresses (up to 2)
+  WiFi.mode(WIFI_STA); 
+  WiFi.config(IPAddress(192, 168, 1, 222), IPAddress(192, 168, 1, 1), IPAddress(192, 168, 1, 0));
   WiFi.begin(ssid, password);
 
   while (WiFi.status() != WL_CONNECTED) {
@@ -64,13 +67,10 @@ void setup(){
 #endif
 }
 
-
-
-
 void loop() {
 
   //Serial.println(digitalRead(12));
-  bool ispressed = false; // keep track if any button press so the press indicator LED can be turned on
+  bool ispressed = false; // keep track if any button is pressed so the press indicator LED can be turned on
 
   // check each button
   for (int i = 0; i < BUTTONS; i++)
@@ -94,14 +94,21 @@ void loop() {
       Serial.print(" : ");
       Serial.println(v);
 #endif
+  
+  // For every button you have installed and configured to work with xSchedule, you must have an "if" statement with the correct "SendData" parameter(s) below.
+  // Make sure both the pin number and the button name are correct.
+  
       if (v == LOW)
       {
         // button is newly pressed
         if (pins[i] == 12) { //Process GPIO 12
-          SendData("/xScheduleCommand?Command=PressButton&Parameters=Next"); //xScheduler button is named Next
+          SendData("/xScheduleCommand?Command=PressButton&Parameters=Next"); //This xScheduler button is named Next
         }
-        if (pins[i] == 14) { //Process GOIO 14
-          SendData ("/xScheduleCommand?Command=PressButton&Parameters=Back");  //xScheduler button is named Back
+        if (pins[i] == 14) { //Process GPIO 14
+          SendData ("/xScheduleCommand?Command=PressButton&Parameters=Back");  //This xScheduler button is named Back
+        }
+        if (pins[i] == 13) { //Process GPIO 13
+          SendData ("/xScheduleCommand?Command=PressButton&Parameters=Other");  //This xScheduler button is named Other
         }
       }
       pressed[i] = v;
@@ -118,8 +125,6 @@ void loop() {
   delay(10);
 
 }
-
-
 
 void SendData (String urlrequest) {
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
-# ESP8266_xScheduleButtonsDemo
+# ESP8266_xScheduleButtonsDemo_v2
 
-This is the modified sketch for the xLights xScheduler interactive button build that shows how to construct a prop for engaging an audience, it  allows someone to manually move backward or forward through a music./light show sequence by selecting a "Back" or "Next" buttons.
-Click the following link to view the video.
+This is the modified sketch for the xLights xScheduler interactive button build that shows how to construct a prop for engaging an audience, it allows someone to manually move backward or forward through a music/light show sequence by selecting a "Back" or "Next" button, and to use other buttons to trigger useful show control actions using the Arduino and xScheduler.
 
-<a href="https://youtu.be/8NWRenqEm_Y">Button Demo Video!</a>
+This version of the project code is based on the work from Wendell Seaton's very good build video and code updates for the wireless Arduino (below), and is used to drive my many buttoned marquee. This version incorporates some lessons learned and provides additional commentary in the code.
+
+Click the following link to view the original build video:
+
+<a href="https://youtu.be/8NWRenqEm_Y">Button Demo Build Video!</a>
 
 <img src="Images/xScheduleButtonView.png" width="400">
+Original 2-Button Prop Up Close
 
+<img src="Images/MarqueeExample.jpg" width="600">
+The Many-Buttoned Marquee
 
 <img src="Images/xScheduleBtnSystem.png" width="300">
+Original 2-Button Prop


### PR DESCRIPTION
…ss boards. Updated pinout list to only include valid input/output pins. Added comments.

Updates to the original repository from FutureTechGuy to shut down access point mode on the WiFi circuit, which was allowing anyone to connect to the network. Also tested the GPIO pins with hardware documentation to remove invalid pins for triggers and lights, moving the "presspin" LED to a better GPIO pin and allowing for the maximum number of function buttons to be used. Comments included to guide customization and necessary edits. 

//Additional commentary: the ESP8266 GPIO pins are not all equally useful for input/output. The "table" below articulates the GPIO pin #, PCB label assignment, whether it can be used for input/output, any notes to caveat the choices, and how the updated code is/should be using those pins. We can safely use 7 GPIO pins for buttons and a handful more for LED indicators. The rest are bad juju. Trust me, I almost bricked the poor Arduino testing these. My edits remove all the dangerous pins from the list and only use the limited functionality pins for LED bulbs. If there's nothing in the "In Use?" column, that pin is not being referenced in my build or the code updates at all.

PCB Label | Actual GPIO   Target | Input | Output | Notes | In Use?
-- | -- | -- | -- | -- | --
D0 | GPIO16 | no interrupt | no PWM or I2C support | HIGH at boot used to wake up from deep sleep | Button 7
D1 | GPIO5 | OK | OK | often used as SCL (I2C) | Button 4
D2 | GPIO4 | OK | OK | often used as SDA (I2C) | Button 5
D3 | GPIO0 | pulled up | OK | connected to FLASH button, boot fails if pulled LOW |  
D4 | GPIO2 | pulled up | OK | HIGH at boot connected to on-board LED, boot fails if   pulled LOW | Presspin LED
D5 | GPIO14 | OK | OK | SPI (SCLK) | Button 1 - Back
D6 | GPIO12 | OK | OK | SPI (MISO) | Button 2 - Next
D7 | GPIO13 | OK | OK | SPI (MOSI) | Button 3 - Other
D8 | GPIO15 | pulled to GND | OK | SPI (CS) Boot fails if pulled HIGH | Powerpin LED
RX | GPIO3 | OK | RX pin | HIGH at boot | Button 6
TX | GPIO1 | TX pin | OK | HIGH at boot debug output at boot, boot fails if pulled   LOW |  
A0 | ADC0 | Analog Input | X |   |  

//More additional commentary: the ESP82XX wifi boards are set by default to both AP and Station mode, which is to say anyone can connect to the Arduino and then hop over your internal network to the show controller, or worse. I discovered this by accident, as the code was throwing "Evt:7" error messages every time a car with an iPhone in it drove past my house. This version of the code shuts that down straightaway.

//Final bit of additional commentary
Some enhancements I wanted but failed to implement: 
1) Move all the variables to the configure.h file. I'm terrible with code and didn't want to mess with anything that would break easily.
2) This looks like a LOT of changes, but it's not. Most of my adds are formatting and comments. I probably did this all wrong, but the code runs, so apologies if I broke some convention. I would like to clean my mess up further, but getting this finished was a priority.
3) Allow for either host by name or host by IP addressing. The code complains about the server address being an IP but goes ahead and does its job regardless. I couldn't make the Arduino resolve a hostname. Might have been an issue with my gateway.
Lastly, I learned two things- don't plug the breakout cape in backward. Looks cool. Makes the Arduino sad. Second: when testing the board/code in its enclosure, plug in the external power FIRST and the USB connector LAST. Since my Arduino is sharing 5VDC power with about 100W of other devices, the overload circuit kicks in if only the USB connector is plugged, and the Arduino goes to sleep. More like a coma, but still, it's useless until you disconnect all the power sources and re-attach them properly.

Co-Authored-By: KinzuaKid <64295066+kinzuakid@users.noreply.github.com>
Co-Authored-By: Wendell Seaton <futuretechguy@gmail.com>